### PR TITLE
fix(userprog): 프로세스 FDT 리소스 관리 로직 추가

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -131,6 +131,8 @@ struct thread {
 
 extern struct list sleep_list;  // sleep 상태인 스레드들을 담는 리스트
 
+#define FDT_SIZE 128 // 파일 디스크립터 테이블 최대 크기
+
 /* If false (default), use round-robin scheduler.
    If true, use multi-level feedback queue scheduler.
    Controlled by kernel command-line option "-o mlfqs". */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -326,7 +326,6 @@ tid_t thread_create(const char *name, int priority, thread_func *function,
   /* 스레드 초기화 */
   init_thread(t, name, priority);
   tid = t->tid = allocate_tid();
-  t->fdt = (struct file **)palloc_get_page(PAL_ZERO);
 
   /* Call the kernel_thread if it scheduled.
    * Note) rdi is 1st argument, and rsi is 2nd argument.

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -163,7 +163,6 @@ int open(const char *file) {
     // exit(-1);
     return -1;
   }
-
   // 2. 사용자 영역 확인
   if (!is_user_vaddr(file)) {
     // exit(-1);
@@ -196,6 +195,7 @@ int open(const char *file) {
     }
     i++;
   }
+
   // 파일 열기
   struct file *f = filesys_open(kernel_file);
   if (!f) {
@@ -205,7 +205,7 @@ int open(const char *file) {
   // 파일 디스크립터 할당
   int fd = 2;
   // fdt의 끝까지 탐색하는 while
-  while (fd < 128) {
+  while (fd < FDT_SIZE) {
     if (curr->fdt[fd] == NULL) {
       curr->fdt[fd] = f;
       return fd;


### PR DESCRIPTION
프로세스의 생명주기에 맞춰 파일 디스크립터 테이블(FDT)을 동적으로 할당하고 해제하는 로직을 추가하여, 메모리 및 파일 리소스 누수를 방지합니다.

주요 변경 사항:
- 프로세스 초기화(`process_init`) 시 FDT를 위한 페이지를 할당하고 0으로 초기화하여 각 프로세스가 독립적인 파일 디스크립터 공간을 갖도록 합니다.
- 프로세스 종료(`process_exit`) 시 열려있는 모든 파일을 `file_close`로 닫고, FDT에 할당된 페이지 메모리를 해제하여 리소스 누수를 방지합니다.
- FDT의 최대 크기를 나타내는 `FDT_SIZE` 매크로를 정의하여 매직 넘버(128)를 제거하고 코드의 가독성과 유지보수성을 향상시킵니다.