### PR TITLE
fix(wait): 자식 프로세스 고아 처리

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -408,6 +408,7 @@ int process_wait(tid_t child_tid) {
     struct thread *t = list_entry(e, struct thread, child_elem);
     if (t->tid == child_tid) {
       child = t;
+      list_remove(&child->child_elem);
       break;
     }
   }
@@ -419,7 +420,6 @@ int process_wait(tid_t child_tid) {
   sema_down(&child->wait_sema);
 
   int status = child->exit_status;
-  list_remove(&child->child_elem);
 
   sema_up(&child->exit_sema);
 
@@ -455,6 +455,7 @@ void process_exit(void) {
   while (!list_empty(&curr->child_list)) {
     struct list_elem *e = list_begin(&curr->child_list);
     struct thread *t = list_entry(e, struct thread, child_elem);
+    sema_up(&t->exit_sema);
     list_remove(&t->child_elem);
   }
 


### PR DESCRIPTION
`list_remove(child_list)`를 자식을 찾자마자 호출

`process_exit()`에서 부모가 모든 자식들의 `sema_up(exit_sema)`을 호출

부모가 먼저 `exit` -> 자식들의 `exit_sema`를 미리 올려줌
자식이 먼저 `exit` -> 부모의 `wait` 호출 시 `exit_status`를 받고 자식의 `exit_sema`를 풀어줌,
                                  부모가 `wait` 호출 없이 `exit` 호출 시 모든 `exit_sema`를 미리 풀어줌