### PR TITLE
[task/182] vm_claim_page 함수 구현

### DIFF
--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -88,6 +88,7 @@ static struct frame *vm_evict_frame(void) {
   return NULL;
 }
 
+/* 물리 프레임 할당 */
 static struct frame *vm_get_frame(void) {
   struct frame *frame = NULL;
   /* TODO: Fill this function. */
@@ -114,9 +115,20 @@ void vm_dealloc_page(struct page *page) {
   free(page);
 }
 
+/*
+ * va(가상 주소)로 해당 페이지 찾아서 vm_do_claim_page() 호출
+ * claim : va(가상주소)를 물리 프레임을 실제로 할당하고 페이지 테이블에 매핑
+ */
 bool vm_claim_page(void *va) {
-  struct page *page = NULL;
-  /* TODO: Fill this function */
+  ASSERT(va != NULL);
+
+  // va로 페이지 찾기
+  struct supplemental_page_table *spt = &thread_current()->spt;
+  struct page *page = spt_find_page(spt, va);
+
+  // 해당하는 페이지가 없으면 실패(false)
+  if (page == NULL) return false;
+
   return vm_do_claim_page(page);
 }
 


### PR DESCRIPTION
# vm_claim_page()
> 🥕 요약 : va를 인자로 받아 spt에서 va를 이용해 페이지를 찾고, vm_do_claim_page 함수를 호출

## 설명
이 함수는 사용자 프로그램이 특정 가상 주소를 사용하고자 요청할 때 호출됩니다.
`userprog/process.c` 파일에서 `load`함수를 실행하는 시점에 `vm_alloc_page` 함수를 이용해 페이지 정보만 SPT에 등록합니다(지연 로딩). 이후에 사용자 프로그램이 해당 주소를 사용하는 명령어를 호출하는 시점에 페이지 폴트가 발생하면서 커널이 `vm_claim_page`를 호출합니다.

## 흐름
1. **사용자 프로그램이 메모리 접근 시도**
    EX : `printf()`
2. **페이지 폴트 발생**(SPT에 페이지 정보만 등록했으니까)
3. 커널이 **`page_fault()` 핸들러 실행**
4. 커널이 **`vm_try_handle_fault()` 함수 실행**
5. 커널이 **`vm_claim_page()` 함수 실행**

---

close #182