### PR TITLE
[task/199] anon_initializer 함수 구현

### DIFF
--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -1,52 +1,57 @@
 /* anon.c: Implementation of page for non-disk image (a.k.a. anonymous page). */
 
-#include "vm/vm.h"
 #include "devices/disk.h"
+#include "vm/vm.h"
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;
-static bool anon_swap_in (struct page *page, void *kva);
-static bool anon_swap_out (struct page *page);
-static void anon_destroy (struct page *page);
+static bool anon_swap_in(struct page *page, void *kva);
+static bool anon_swap_out(struct page *page);
+static void anon_destroy(struct page *page);
 
 /* DO NOT MODIFY this struct */
 static const struct page_operations anon_ops = {
-	.swap_in = anon_swap_in,
-	.swap_out = anon_swap_out,
-	.destroy = anon_destroy,
-	.type = VM_ANON,
+    .swap_in = anon_swap_in,
+    .swap_out = anon_swap_out,
+    .destroy = anon_destroy,
+    .type = VM_ANON,
 };
 
 /* Initialize the data for anonymous pages */
-void
-vm_anon_init (void) {
-	/* TODO: Set up the swap_disk. */
-	swap_disk = NULL;
+void vm_anon_init(void) {
+  /* TODO: Set up the swap_disk. */
+  swap_disk = NULL;
 }
 
 /* Initialize the file mapping */
-bool
-anon_initializer (struct page *page, enum vm_type type, void *kva) {
-	/* Set up the handler */
-	page->operations = &anon_ops;
+/* 익명 페이지(VM_ANON)의 초기화 인자로 사용되는 함수 */
+bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
+  ASSERT(type == VM_ANON);
+  ASSERT(page->frame != NULL);
 
-	struct anon_page *anon_page = &page->anon;
+  /* Set up the handler */
+  page->operations = &anon_ops;
+
+  struct anon_page *anon_page = &page->anon;
+  /*
+   * TODO : Swap 구현할 때 필요한 초기화 코드 추가할 것
+   * (anon_page 필드 추가도 포함해서)
+   */
+
+  return true;
 }
 
 /* Swap in the page by read contents from the swap disk. */
-static bool
-anon_swap_in (struct page *page, void *kva) {
-	struct anon_page *anon_page = &page->anon;
+static bool anon_swap_in(struct page *page, void *kva) {
+  struct anon_page *anon_page = &page->anon;
 }
 
 /* Swap out the page by writing contents to the swap disk. */
-static bool
-anon_swap_out (struct page *page) {
-	struct anon_page *anon_page = &page->anon;
+static bool anon_swap_out(struct page *page) {
+  struct anon_page *anon_page = &page->anon;
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */
-static void
-anon_destroy (struct page *page) {
-	struct anon_page *anon_page = &page->anon;
+static void anon_destroy(struct page *page) {
+  struct anon_page *anon_page = &page->anon;
 }


### PR DESCRIPTION
# anon_initializer 함수 구현
> 사실 변경된 내용이 없습니다

`anon_initializer` 함수 구현에서는 anon_page라는 구조체를 사용합니다. 
```c
// 현재 anon_page 구조체 필드 내용 : 없음
struct anon_page {
};
```

`anon_initializer` 함수는 페이지 폴트가 발생하고 `vm_do_claim_page` 함수를 실행하는 과정에서 `swap_in` 함수가 호출되고, `uninit_initialize`를 자동 호출하면서 `uninit_initialize`는 `anon_initializer`를 호출하는 흐름입니다. 당장은 스와핑을 사용하기 전에는 수정할 코드가 없더라구요.
`swap_in` & `swap_out`을 구현하면서 `anon_page` 구조체 필드를 확장하고 이 함수에서 익명 페이지 구조체를 초기화하는 로직을 추가해야하는 듯 합니다.

---

close #199