### PR TITLE
[task/201] lazy_load_segment 섹션 구현 

### DIFF
--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -56,6 +56,7 @@ struct page {
   /* Project_3 Memory Management */
   struct hash_elem hash_elem;
   bool writable;
+  bool is_stack;
   /* Per-type data are binded into the union.
    * Each function automatically detects the current union */
   union {
@@ -109,7 +110,10 @@ void spt_remove_page(struct supplemental_page_table *spt, struct page *page);
 void vm_init(void);
 bool vm_try_handle_fault(struct intr_frame *f, void *addr, bool user,
                          bool write, bool not_present);
-
+/* vm_alloc_page() : 가상 메모리 페이지를 할당하는 함수
+ * 내부적으로는 vm_alloc_page_with_initializer()를 호출
+ * 초기화 함수와 보조 데이터를 NULL로 전달하여 기본 페이지 할당 수행
+ */
 #define vm_alloc_page(type, upage, writable) \
   vm_alloc_page_with_initializer((type), (upage), (writable), NULL, NULL)
 bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -788,6 +788,7 @@ static bool load_segment(struct file* file, off_t ofs, uint8_t* upage,
 }
 
 /* Create a minimal stack by mapping a zeroed page at the USER_STACK */
+/* Project 2에서 사용하는 setup_stack 함수 */
 static bool setup_stack(struct intr_frame* if_) {
   uint8_t* kpage;
   bool success = false;
@@ -901,15 +902,25 @@ static bool load_segment(struct file* file, off_t ofs, uint8_t* upage,
 }
 
 /* Create a PAGE of stack at the USER_STACK. Return true on success. */
+/* Project 3에서 사용하는 setup_stack 함수 */
 static bool setup_stack(struct intr_frame* if_) {
-  bool success = false;
   void* stack_bottom = (void*)(((uint8_t*)USER_STACK) - PGSIZE);
 
-  /* TODO: Map the stack on stack_bottom and claim the page immediately.
-   * TODO: If success, set the rsp accordingly.
-   * TODO: You should mark the page is stack. */
-  /* TODO: Your code goes here */
+  /* 1. stack_bottom 주소에 익명 페이지를 할당 */
+  if (!vm_alloc_page(VM_ANON, stack_bottom, true)) return false;
 
-  return success;
+  /* 2. 페이지를 실제 물리 메모리에 할당(매핑) */
+  if (!vm_claim_page(stack_bottom)) return false;
+
+  /* 3. 페이지가 스택임을 표시 */
+  struct page* page = spt_find_page(&thread_current()->spt, stack_bottom);
+  if (page == NULL) return false;  // 페이지 찾기 실패 시 false 반환
+
+  page->is_stack = true;
+
+  /* 4. rsp 레지스터를 스택 최상단으로 설정 */
+  if_->rsp = USER_STACK;
+
+  return true;
 }
 #endif /* VM */


### PR DESCRIPTION
# lazy_load_segment 섹션 구현
> 굳이 section이라고 하는건, lazy_load_segment를 구현하면서 두 개의 함수를 추가 구현해야했기 때문입니다.

## lazy_load_segement
> 페이지 폴트 발생 시 파일에서 필요한 데이터만 읽어와 메모리에 적재하도록 구현하였습니다. 파일 오프셋, 읽기 바이트, 0으로 채울 바이트 등 aux 정보를 활용하여 요구사항에 맞게 동작합니다.

## setup_stack
> 스택 페이지를 익명 페이지로 할당하고, 즉시 claim하여 물리 프레임을 매핑합니다. 해당 페이지의 is_stack 필드를 true로 설정하여 스택임을 명확히 표시합니다. rsp 레지스터를 USER_STACK으로 초기화합니다.

## vm_try_handle_fault
> 페이지 폴트 발생 시 SPT에서 해당 페이지를 찾아 claim(=lazy loading)합니다. 페이지가 없을 경우 false를 반환하며, 향후 스택 성장 및 권한 처리 등 확장 가능성을 고려하여 TODO로 남겨두었습니다.

---

close #201