### PR TITLE
[task/203] supplemental_page_table_kill 구현

### DIFF
--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -237,9 +237,14 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst,
   return false;
 }
 
+/* 아래 spt_kill 함수에서 콜백 함수로 전달하기 위한 함수 */
+static void spt_hash_destroy_func(struct hash_elem *e, void *aux) {
+  struct page *page = hash_entry(e, struct page, hash_elem);
+  vm_dealloc_page(page);  // destroy + free
+}
+
 void supplemental_page_table_kill(struct supplemental_page_table *spt) {
-  /* TODO: Destroy all the supplemental_page_table hold by thread and
-   * writeback all the modified contents to the storage. */
+  hash_destroy(&spt->spt_hash, spt_hash_destroy_func);
 }
 
 uint64_t spt_hash_func(const struct hash_elem *e, void *aux) {


### PR DESCRIPTION
# supplemental_page_table_kill 구현

## spt_hash_destroy_func
> 🥕 `supplemental_page_table_kill` 함수가 콜백함수로서 인자 전달하기 위한 함수

`hash_entry` 함수를 통해 `hash_elem *e` 인자로부터 page를 찾아내고, `vm_dealloc_page(page)`을 호출하는 함수
```c
static void spt_hash_destroy_func(struct hash_elem *e, void *aux) {
  struct page *page = hash_entry(e, struct page, hash_elem);
  vm_dealloc_page(page);  // destroy + free
}
```

### vm_dealloc_page
```c
void vm_dealloc_page(struct page *page) {
  destroy(page); // 
  free(page); // 페이지 구조체 메모리 해제
}
```

#### destroy
> page 구조체에는 operations 구조체 타입의 필드가 존재하고, operations는 여러 연산자(swap_in, swap_out, destroy)를 함수 포인터로 주소값을 가지고 있습니다. destroy는 페이지 자원을 모두 정리하는 역할의 함수인가 봅니다.

```c
#define destroy(page) \
  if ((page)->operations->destroy) (page)->operations->destroy(page)
```

## supplemental_page_table_kill
> 🥕 #203 내용을 참고해주세요

`spt_hash_destroy_func` 함수를 두 번째 인자로 전달합니다. `hash_destroy` 함수 내부 로직에서 `hash_clear` 함수를 호출하고, `hash_clear`함수 로직을 진행하면 버킷들을 순회하면서 연결리스트로 연결된 요소들을 콜백 함수로 전달받은 `spt_hash_destroy_func`를 이용해 정리합니다.
```c
void supplemental_page_table_kill(struct supplemental_page_table *spt) {
  hash_destroy(&spt->spt_hash, spt_hash_destroy_func);
}
```

---

close #203