### PR TITLE
[task/204] uninit_destroy 구현

### DIFF
--- a/pintos/vm/uninit.c
+++ b/pintos/vm/uninit.c
@@ -56,7 +56,7 @@ static bool uninit_initialize(struct page *page, void *kva) {
  * exit, which are never referenced during the execution.
  * PAGE will be freed by the caller. */
 static void uninit_destroy(struct page *page) {
-  struct uninit_page *uninit UNUSED = &page->uninit;
+  struct uninit_page *uninit = &page->uninit;
   if (uninit->aux != NULL) {
     free(uninit->aux);
   }


### PR DESCRIPTION
### `uninit_destroy `
   - 사용하지 않은 uninit 페이지의 aux 메모리 해제
 
   
 ###  순환 include 제거
   - `vm/uninit.h include` 제거하여 `vm.h` ↔ `uninit.h` 순환 방지
   - `struct uninit_page`는 `vm.h`에 정의되어 있어 `uninit.c`에서 `vm.h`만 include

close #204 